### PR TITLE
アカウント設定ページを追加し、プロフィールとパスワードの更新を可能にします

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import MainLayout from "./pages/mainlayout/MainLayout";
 import MyRegister from "./pages/register/MyRegister";
 import MyTable from "./pages/table/MyTable";
 import NoMatch from "./pages/mainlayout/NoMatch";
+import Profile from "./pages/AccountSettings/AccountSettings";
 
 import { useState } from "react";
 import { Navigate, useNavigate } from "react-router";
@@ -128,6 +129,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <MySetting />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="AccountSettings"
+              element={
+                <ProtectedRoute>
+                  <Profile />
                 </ProtectedRoute>
               }
             />

--- a/src/pages/AccountSettings/AccountSettings.tsx
+++ b/src/pages/AccountSettings/AccountSettings.tsx
@@ -1,0 +1,25 @@
+import { Container, Tabs } from "@chakra-ui/react";
+import Profile from "./Profile.tsx";
+import Password from "./Password.tsx";
+
+function AccountSettings() {
+  return (
+    <>
+      <Container p={8}>
+        <Tabs.Root defaultValue="Profile">
+          <Tabs.List>
+            <Tabs.Trigger value="Profile">Profile</Tabs.Trigger>
+            <Tabs.Trigger value="Password">Password</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="Profile">
+            <Profile />
+          </Tabs.Content>
+          <Tabs.Content value="Password">
+            <Password />
+          </Tabs.Content>
+        </Tabs.Root>
+      </Container>
+    </>
+  );
+}
+export default AccountSettings;

--- a/src/pages/AccountSettings/CompletedContent.tsx
+++ b/src/pages/AccountSettings/CompletedContent.tsx
@@ -1,0 +1,20 @@
+import { EmptyState, VStack } from "@chakra-ui/react";
+import { TbPasswordUser } from "react-icons/tb";
+
+export default function CompletedContent() {
+  return (
+    <EmptyState.Root>
+      <EmptyState.Content>
+        <EmptyState.Indicator>
+          <TbPasswordUser />
+        </EmptyState.Indicator>
+        <VStack textAlign="center">
+          <EmptyState.Title>新しいパスワードの設定完了</EmptyState.Title>
+          <EmptyState.Description>
+            次回から新しいパスワードでログインしてください。
+          </EmptyState.Description>
+        </VStack>
+      </EmptyState.Content>
+    </EmptyState.Root>
+  );
+}

--- a/src/pages/AccountSettings/DialogProfileEdit.tsx
+++ b/src/pages/AccountSettings/DialogProfileEdit.tsx
@@ -1,0 +1,117 @@
+import type { ProfileType } from "@/types/accountSettings";
+import { putWithAuth } from "@/utils/putWithAuth";
+import { useAuth } from "@/utils/useAuth";
+import {
+  Button,
+  CloseButton,
+  Dialog,
+  Field,
+  Input,
+  Portal,
+  Stack,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+type dialogProfileEditProps = {
+  isDialogOpen: boolean;
+  setIsDialogOpen: (isOpen: boolean) => void;
+  defaultValues: ProfileType;
+  setProfile: (profile: ProfileType) => void;
+};
+
+export default function DialogProfileEdit({
+  isDialogOpen,
+  setIsDialogOpen,
+  defaultValues,
+  setProfile,
+}: dialogProfileEditProps) {
+  const [loading, setLoading] = useState<boolean>(false);
+  const { onLogout } = useAuth();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ProfileType>({
+    defaultValues,
+  });
+
+  const onsubmit = async (data: ProfileType) => {
+    setLoading(true);
+
+    try {
+      const changedProfile = await putWithAuth("/profile", data);
+      setProfile(changedProfile);
+    } catch (err) {
+      console.error(err);
+      onLogout();
+    } finally {
+      setLoading(false);
+      setIsDialogOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog.Root
+        open={isDialogOpen}
+        onOpenChange={(details) => setIsDialogOpen(details.open)}
+        placement="center"
+      >
+        <Portal>
+          <Dialog.Backdrop />
+          <Dialog.Positioner>
+            <Dialog.Content>
+              <form onSubmit={handleSubmit(onsubmit)} noValidate>
+                <Dialog.CloseTrigger asChild>
+                  <CloseButton />
+                </Dialog.CloseTrigger>
+
+                <Dialog.Header>
+                  <Dialog.Title>プロフィール編集</Dialog.Title>
+                </Dialog.Header>
+
+                <Dialog.Body>
+                  <Stack gap="4" w="full">
+                    <Field.Root invalid={!!errors.name}>
+                      <Field.Label>Name</Field.Label>
+                      <Input
+                        placeholder="ユーザ名を入力"
+                        {...register("name", {
+                          required: "名前は必須です",
+                        })}
+                      />
+                      <Field.ErrorText>{errors.name?.message}</Field.ErrorText>
+                    </Field.Root>
+                    <Field.Root invalid={!!errors.email}>
+                      <Field.Label>Email</Field.Label>
+                      <Input
+                        placeholder="メールアドレスを入力"
+                        {...register("email", {
+                          required: "メールアドレスは必須です",
+                        })}
+                      />
+                      <Field.ErrorText>{errors.email?.message}</Field.ErrorText>
+                    </Field.Root>
+                  </Stack>
+                </Dialog.Body>
+                <Dialog.Footer>
+                  <Button
+                    type="submit"
+                    loading={loading}
+                    colorPalette="green"
+                    variant="solid"
+                    w="full"
+                  >
+                    更新
+                  </Button>
+                </Dialog.Footer>
+              </form>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Portal>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/src/pages/AccountSettings/InvalidError.tsx
+++ b/src/pages/AccountSettings/InvalidError.tsx
@@ -1,0 +1,12 @@
+import { Alert } from "@chakra-ui/react";
+
+export default function InvalidAlert() {
+  return (
+    <Alert.Root status="error" mb={4}>
+      <Alert.Indicator />
+      <Alert.Content>
+        <Alert.Title>パスワードが違います</Alert.Title>
+      </Alert.Content>
+    </Alert.Root>
+  );
+}

--- a/src/pages/AccountSettings/NewPasswordForm.tsx
+++ b/src/pages/AccountSettings/NewPasswordForm.tsx
@@ -1,0 +1,103 @@
+import { putWithAuth } from "@/utils/putWithAuth";
+import { Button, Card, Field, Input, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import type { NewPasswordType } from "../../types/accountSettings.ts";
+import { useAuth } from "@/utils/useAuth.tsx";
+
+type newPasswordFormProps = {
+  setIsCheckCompleted: (value: boolean) => void;
+};
+
+export default function NewPasswordForm({
+  setIsCheckCompleted,
+}: newPasswordFormProps) {
+  const [loading, setLoading] = useState<boolean>(false);
+  const { onLogout } = useAuth();
+  const defaultValues: NewPasswordType = {
+    newPassword: "",
+    confirmNewPassword: "",
+  };
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm<NewPasswordType>({
+    defaultValues,
+  });
+  const newPassword = watch("newPassword");
+
+  const onsubmit = async (data: NewPasswordType) => {
+    setLoading((prev) => !prev);
+
+    try {
+      await putWithAuth("/setNewPassword", data);
+    } catch (err) {
+      console.error(err);
+      onLogout();
+    } finally {
+      setIsCheckCompleted(true);
+      setLoading((prev) => !prev);
+      reset(defaultValues);
+    }
+  };
+
+  return (
+    <Card.Root>
+      <form onSubmit={handleSubmit(onsubmit)} noValidate>
+        <Card.Header>
+          <Card.Title>新しいパスワードを設定</Card.Title>
+        </Card.Header>
+        <Card.Body>
+          <Stack gap="4" w="full">
+            <Field.Root invalid={!!errors.newPassword}>
+              <Field.Label>新しいパスワード</Field.Label>
+              <Input
+                p="2"
+                borderWidth="1px"
+                borderRadius="md"
+                w="full"
+                type="password"
+                {...register("newPassword", {
+                  required: "新しいパスワードを入力してください",
+                })}
+              />
+              <Field.ErrorText>{errors.newPassword?.message}</Field.ErrorText>
+            </Field.Root>
+            <Field.Root invalid={!!errors.confirmNewPassword}>
+              <Field.Label>新しいパスワード（確認用）</Field.Label>
+              <Input
+                p="2"
+                borderWidth="1px"
+                borderRadius="md"
+                w="full"
+                type="password"
+                {...register("confirmNewPassword", {
+                  required: "確認用パスワードを入力してください",
+                  validate: (value) =>
+                    value === newPassword || "パスワードが一致しません",
+                })}
+              />
+              <Field.ErrorText>
+                {errors.confirmNewPassword?.message}
+              </Field.ErrorText>
+            </Field.Root>
+          </Stack>
+        </Card.Body>
+        <Card.Footer justifyContent="flex-end">
+          <Button
+            type="submit"
+            colorPalette="green"
+            variant="solid"
+            loading={loading}
+          >
+            確認
+          </Button>
+        </Card.Footer>
+      </form>
+    </Card.Root>
+  );
+}

--- a/src/pages/AccountSettings/Password.tsx
+++ b/src/pages/AccountSettings/Password.tsx
@@ -1,0 +1,79 @@
+import { Button, ButtonGroup, Card, Steps, VStack } from "@chakra-ui/react";
+import VerifyPassword from "./VerifyPassword";
+import { useEffect, useState } from "react";
+import CompletedContent from "./CompletedContent";
+import NewPasswordForm from "./NewPasswordForm";
+
+const Password = () => {
+  const [isCheckCompleted, setIsCheckCompleted] = useState<boolean>(false);
+  const [isCheckError, setIsCheckError] = useState<boolean>(false);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    if (isCheckCompleted) {
+      setStep((prevStep) => prevStep + 1);
+      setIsCheckCompleted(false);
+      setIsCheckError(false);
+    }
+  }, [isCheckCompleted]);
+
+  return (
+    <Card.Root p={4}>
+      <Card.Body alignItems="center">
+        <Steps.Root
+          defaultStep={0}
+          count={2}
+          maxW="700px"
+          step={step}
+          onStepChange={(e) => setStep(e.step)}
+        >
+          <Steps.List>
+            <Steps.Item index={0} title="Step 1">
+              <VStack>
+                <Steps.Indicator />
+                <Steps.Title>Step 1</Steps.Title>
+              </VStack>
+              <Steps.Separator />
+            </Steps.Item>
+            <Steps.Item index={1} title="Step 2">
+              <VStack>
+                <Steps.Indicator />
+                <Steps.Title>Step 2</Steps.Title>
+              </VStack>
+              <Steps.Separator />
+            </Steps.Item>
+          </Steps.List>
+
+          <Steps.Content index={0}>
+            <VerifyPassword
+              setIsCheckCompleted={setIsCheckCompleted}
+              isCheckError={isCheckError}
+              setIsCheckError={setIsCheckError}
+            />
+          </Steps.Content>
+          <Steps.Content index={1}>
+            <NewPasswordForm setIsCheckCompleted={setIsCheckCompleted} />
+          </Steps.Content>
+
+          <Steps.CompletedContent>
+            <CompletedContent />
+          </Steps.CompletedContent>
+
+          <ButtonGroup size="sm" variant="outline" justify="flex-end">
+            {step !== 2 ? (
+              <Steps.PrevTrigger asChild>
+                <Button>Prev</Button>
+              </Steps.PrevTrigger>
+            ) : (
+              <Button onClick={() => setStep(0)} ml={2}>
+                最初に戻る
+              </Button>
+            )}
+          </ButtonGroup>
+        </Steps.Root>
+      </Card.Body>
+    </Card.Root>
+  );
+};
+
+export default Password;

--- a/src/pages/AccountSettings/Profile.tsx
+++ b/src/pages/AccountSettings/Profile.tsx
@@ -1,0 +1,108 @@
+import { fetchWithAuth } from "@/utils/fetchWithAuth";
+import {
+  Box,
+  Button,
+  Card,
+  Field,
+  SkeletonText,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { useAuth } from "../../utils/useAuth.tsx";
+import DialogProfileEdit from "./DialogProfileEdit.tsx";
+
+type ProfileType = {
+  name: string;
+  email: string;
+};
+
+const Profile = () => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [profile, setProfile] = useState<ProfileType>({ name: "", email: "" });
+  const { onLogout } = useAuth();
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        setLoading(true);
+        const data = await fetchWithAuth("/profile");
+        setProfile(data);
+      } catch (err) {
+        console.error(err);
+        onLogout();
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadProfile();
+  }, [onLogout]);
+
+  return (
+    <>
+      <Card.Root>
+        <Card.Header>
+          <Card.Title>Profile</Card.Title>
+        </Card.Header>
+        <Card.Body>
+          <Stack gap="4" w="full">
+            <Field.Root>
+              <Field.Label>Name</Field.Label>
+              <Box
+                p="2"
+                borderWidth="1px"
+                borderRadius="md"
+                w="full"
+                color="gray.500"
+              >
+                {loading ? (
+                  <SkeletonText noOfLines={1} />
+                ) : (
+                  <Text>{profile?.name}</Text>
+                )}
+              </Box>
+            </Field.Root>
+            <Field.Root>
+              <Field.Label>Email</Field.Label>
+              <Box
+                p="2"
+                borderWidth="1px"
+                borderRadius="md"
+                w="full"
+                color="gray.500"
+              >
+                {loading ? (
+                  <SkeletonText noOfLines={1} />
+                ) : (
+                  <Text>{profile?.email}</Text>
+                )}
+              </Box>
+            </Field.Root>
+          </Stack>
+        </Card.Body>
+        <Card.Footer justifyContent="flex-end">
+          <Button
+            variant="solid"
+            colorPalette="green"
+            onClick={() => {
+              setIsDialogOpen(!isDialogOpen);
+            }}
+          >
+            編集
+          </Button>
+        </Card.Footer>
+      </Card.Root>
+
+      {isDialogOpen && (
+        <DialogProfileEdit
+          isDialogOpen={isDialogOpen}
+          setIsDialogOpen={setIsDialogOpen}
+          defaultValues={profile}
+          setProfile={setProfile}
+        />
+      )}
+    </>
+  );
+};
+export default Profile;

--- a/src/pages/AccountSettings/VerifyPassword.tsx
+++ b/src/pages/AccountSettings/VerifyPassword.tsx
@@ -1,0 +1,88 @@
+import type { CurrentPasswordType } from "@/types/accountSettings";
+import { postWithAuth } from "@/utils/postWithAuth";
+import { Button, Card, Field, Input, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import InvalidAlert from "./InvalidError";
+
+type VerifyPasswordProps = {
+  setIsCheckCompleted: (value: boolean) => void;
+  isCheckError: boolean;
+  setIsCheckError: (value: boolean) => void;
+};
+
+export default function VerifyPassword({
+  setIsCheckCompleted,
+  isCheckError,
+  setIsCheckError,
+}: VerifyPasswordProps) {
+  const [loading, setLoading] = useState<boolean>(false);
+  const defaultValues: CurrentPasswordType = {
+    currentPassword: "",
+  };
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CurrentPasswordType>({
+    defaultValues,
+  });
+
+  const onsubmit = async (data: CurrentPasswordType) => {
+    setLoading(true);
+
+    try {
+      const res = await postWithAuth("/checkPassword", data);
+      setIsCheckCompleted(Boolean(res.message));
+    } catch (err) {
+      console.error(err);
+      setIsCheckError(true);
+    } finally {
+      reset(defaultValues);
+      setLoading(false);
+    }
+  };
+  return (
+    <>
+      {isCheckError && <InvalidAlert />}
+      <Card.Root>
+        <form onSubmit={handleSubmit(onsubmit)} noValidate>
+          <Card.Header>
+            <Card.Title>現在のパスワードを確認</Card.Title>
+          </Card.Header>
+          <Card.Body>
+            <Stack gap="4" w="full">
+              <Field.Root invalid={!!errors.currentPassword}>
+                <Field.Label>現在のパスワードを入力してください</Field.Label>
+                <Input
+                  p="2"
+                  borderWidth="1px"
+                  borderRadius="md"
+                  w="full"
+                  type="password"
+                  {...register("currentPassword", {
+                    required: "現在のパスワードは必須です",
+                  })}
+                />
+                <Field.ErrorText>
+                  {errors.currentPassword?.message}
+                </Field.ErrorText>
+              </Field.Root>
+            </Stack>
+          </Card.Body>
+          <Card.Footer justifyContent="flex-end">
+            <Button
+              type="submit"
+              colorPalette="green"
+              variant="solid"
+              loading={loading}
+            >
+              確認
+            </Button>
+          </Card.Footer>
+        </form>
+      </Card.Root>
+    </>
+  );
+}

--- a/src/pages/category/CategoriesForm.tsx
+++ b/src/pages/category/CategoriesForm.tsx
@@ -139,14 +139,11 @@ export default function CategoriesForm({
           />
         </Field.Root>
 
-        <Field.Root>
+        <Field.Root
+          disabled={registrationDate === "" || registrationDate === null}
+        >
           <Field.Label>金額</Field.Label>
-          <Input
-            type="number"
-            variant="outline"
-            {...register("amount")}
-            disabled={registrationDate === "" || registrationDate === null}
-          />
+          <Input type="number" variant="outline" {...register("amount")} />
         </Field.Root>
       </Stack>
 

--- a/src/pages/login/LoginLayout.tsx
+++ b/src/pages/login/LoginLayout.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from "@chakra-ui/react";
+import { Box, Flex, VStack } from "@chakra-ui/react";
 import { Outlet, NavLink, type NavLinkRenderProps } from "react-router";
 
 const loginPages = [
@@ -25,31 +25,40 @@ export default function LoginLayout() {
         justifyContent="center"
         alignItems="center"
       >
-        <Box
-          bg="white"
-          w={{ base: "80vw", md: "40vw" }}
-          h={{ base: "50vh", md: "65vh" }}
-          boxShadow="lg"
-        >
-          <Box>
-            <Flex
-              justify="space-evenly"
-              textAlign="center"
-              alignItems="center"
-              h="100%"
-              p="4"
-            >
-              {loginPages.map((loginPage) => (
-                <NavLink key={loginPage.path} to={loginPage.path} style={style}>
-                  {loginPage.page}
-                </NavLink>
-              ))}
-            </Flex>
+        <VStack>
+          <Box
+            bg="white"
+            w={{ base: "80vw", md: "40vw" }}
+            h={{ base: "50vh", md: "65vh" }}
+            boxShadow="lg"
+          >
+            <Box>
+              <Flex
+                justify="space-evenly"
+                textAlign="center"
+                alignItems="center"
+                h="100%"
+                p="4"
+              >
+                {loginPages.map((loginPage) => (
+                  <NavLink
+                    key={loginPage.path}
+                    to={loginPage.path}
+                    style={style}
+                  >
+                    {loginPage.page}
+                  </NavLink>
+                ))}
+              </Flex>
+            </Box>
+            <Box>
+              <Outlet />
+            </Box>
           </Box>
-          <Box>
-            <Outlet />
-          </Box>
-        </Box>
+          {/* <Link to="AccountSettings/Password">
+            パスワードをお忘れの方はこちら
+          </Link> */}
+        </VStack>
       </Box>
     </>
   );

--- a/src/pages/login/Signin.tsx
+++ b/src/pages/login/Signin.tsx
@@ -57,12 +57,6 @@ export default function Signin() {
           >
             ログイン
           </Button>
-          {/* <PositiveButton
-            loading={loading}
-            onClick={handleLogin}
-            loadingText="ログイン中..."
-            buttonText="ログイン"
-          /> */}
         </Card.Footer>
       </Card.Root>
     </>

--- a/src/pages/mainlayout/MyDrawer.tsx
+++ b/src/pages/mainlayout/MyDrawer.tsx
@@ -51,7 +51,12 @@ export default function MyDrawer() {
               )}
             </Box>
           ))}
-          <Box pb="8">
+          <Box>
+            <Link to="/AccountSettings" onClick={() => setIsOpen(false)}>
+              <Heading size={{ base: "lg", md: "xl" }}>アカウント設定</Heading>
+            </Link>
+          </Box>
+          <Box>
             <Link to="/" onClick={onLogout}>
               <Heading size={{ base: "lg", md: "xl" }}>ログアウト</Heading>
             </Link>

--- a/src/types/accountSettings.ts
+++ b/src/types/accountSettings.ts
@@ -1,0 +1,13 @@
+export type ProfileType = {
+  name: string;
+  email: string;
+};
+
+export type CurrentPasswordType = {
+  currentPassword: string;
+};
+
+export type NewPasswordType = {
+  newPassword: string;
+  confirmNewPassword: string;
+};

--- a/src/utils/postWithAuth.tsx
+++ b/src/utils/postWithAuth.tsx
@@ -1,9 +1,10 @@
 import type { Category } from "../types/mysetting.ts";
 import type { Transaction } from "../types/myregister.ts";
+import type { CurrentPasswordType } from "@/types/accountSettings";
 
 export const postWithAuth = async (
   url: string,
-  postData: Category | Transaction
+  postData: Category | Transaction | CurrentPasswordType
 ) => {
   const baseUrl = import.meta.env.VITE_API_BASE_URL;
   let accessToken = localStorage.getItem("accessToken");

--- a/src/utils/putWithAuth.tsx
+++ b/src/utils/putWithAuth.tsx
@@ -1,9 +1,10 @@
 import type { Category } from "@/types/mysetting.ts";
 import type { Transaction } from "../types/myregister.ts";
+import type { ProfileType, NewPasswordType } from "@/types/accountSettings.ts";
 
 export const putWithAuth = async (
   url: string,
-  putData: Transaction | Category
+  putData: Transaction | Category | ProfileType | NewPasswordType
 ) => {
   const baseUrl = import.meta.env.VITE_API_BASE_URL;
   let accessToken = localStorage.getItem("accessToken");


### PR DESCRIPTION
新しいアカウント設定セクションを導入し、保護されたUIを通じてユーザーがプロフィールを表示・編集し、パスワードを変更できるようにします。検証機能付きプロフィール編集、現在のパスワード確認、ステップベースのナビゲーションとフィードバックを備えた新パスワード設定を実装します。ユーザーエクスペリエンス向上のため、ナビゲーションとドロワーを更新し、新しい設定ページへリンクします。